### PR TITLE
Release v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Grunt plugin for [node-html-auditor](https://github.com/wfp/node-html-auditor).
 
 [![npm](https://img.shields.io/npm/v/grunt-html-auditor.svg?maxAge=2592000?style=flat-square)](https://github.com/matthewmorek/grunt-html-auditor/releases)
-[![Travis branch](https://img.shields.io/travis/matthewmorek/grunt-html-auditor/v1.0.0.svg?maxAge=2592000?style=flat-square)](github.com/matthewmorek/grunt-html-auditor)
+[![Travis branch](https://img.shields.io/travis/matthewmorek/grunt-html-auditor/master.svg?maxAge=2592000?style=flat-square)](github.com/matthewmorek/grunt-html-auditor)
 
 ## Getting Started
 This plugin requires Grunt `~0.4.5`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # grunt-html-auditor
 
-> Grunt plugin for [node-html-auditor](github.com/wfp/node-html-auditor).
+> Grunt plugin for [node-html-auditor](https://github.com/wfp/node-html-auditor).
 
-[![npm](https://img.shields.io/npm/v/grunt-html-auditor.svg?maxAge=2592000?style=flat-square)](https://github.com/matthewmorek/grunt-html-auditor/releases/tag/v1.0.0)
+[![npm](https://img.shields.io/npm/v/grunt-html-auditor.svg?maxAge=2592000?style=flat-square)](https://github.com/matthewmorek/grunt-html-auditor/releases)
 [![Travis branch](https://img.shields.io/travis/matthewmorek/grunt-html-auditor/v1.0.0.svg?maxAge=2592000?style=flat-square)](github.com/matthewmorek/grunt-html-auditor)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Grunt plugin for [node-html-auditor](https://github.com/wfp/node-html-auditor).
 
 [![npm](https://img.shields.io/npm/v/grunt-html-auditor.svg?maxAge=2592000?style=flat-square)](https://github.com/matthewmorek/grunt-html-auditor/releases)
-[![Travis branch](https://img.shields.io/travis/matthewmorek/grunt-html-auditor/master.svg?maxAge=2592000?style=flat-square)](github.com/matthewmorek/grunt-html-auditor)
+[![master](https://img.shields.io/travis/matthewmorek/grunt-html-auditor/master.svg?maxAge=2592000?style=flat-square)](https://github.com/matthewmorek/grunt-html-auditor)
 
 ## Getting Started
 This plugin requires Grunt `~0.4.5`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-auditor",
   "description": "Grunt plugin for `node-html-auditor` package.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/matthewmorek/grunt-html-auditor",
   "author": {
     "name": "Matthew Morek",

--- a/tasks/htmlaudit.js
+++ b/tasks/htmlaudit.js
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
     async.eachSeries(files, function (file, fileDone) {
       async.waterfall([
         function init(done) {
-          grunt.log.writeln(chalk.cyan.bold('> Processing file: ' + file.filename));
+          grunt.log.writeln(chalk.white.bold('> Processing file: ' + file.file));
 
           var data = {
             options: options,

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -44,9 +44,9 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['a11y', '--path', data.file.file], function (error, result, code) {
+  execFile(bin, ['a11y', '--path', data.file.src], function (error, result, code) {
     if (error) {
-      data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.file);
+      data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.src);
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
@@ -58,7 +58,7 @@ module.exports = function (data, done) {
     data.logger(chalk.yellow(JSON.stringify(results)));
 
     if (Object.keys(results).length > 0) {
-      var messages = results[data.file.file];
+      var messages = results[data.file.src];
       if (Object.keys(messages).length > 0) {
         var count = {
           errors: 0,

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -46,8 +46,8 @@ module.exports = function (data, done) {
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile(bin, ['a11y', '--path', data.file.file], function (error, result, code) {
     if (error) {
-      data.logger(chalk.red(result));
-      data.logger(chalk.red(code));
+      data.grunt.log.writeln(chalk.red(result));
+      data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);
     }
 

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -46,6 +46,7 @@ module.exports = function (data, done) {
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile(bin, ['a11y', '--path', data.file.file], function (error, result, code) {
     if (error) {
+      data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.file);
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -37,16 +37,16 @@ module.exports = function (data, done) {
     return;
   }
 
-  data.grunt.log.writeln(chalk.dim('------------'));
-  data.grunt.log.writeln(chalk.yellow.bold('> Checking page against WCAG2 guidelines...'));
+  data.grunt.log.writeln('');
+  data.grunt.log.writeln(chalk.white.bold('> Checking page against WCAG2 guidelines...'));
+
   if (!data.options.showSummaryOnly) {
     data.grunt.log.writeln('');
   }
 
-  var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile('html-audit', ['a11y', '--path', data.file.src], function (error, result, code) {
     if (error) {
-      data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.src);
+      data.grunt.log.writeln('Running: html-auditor a11y --path ' + data.file.src);
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
@@ -96,7 +96,7 @@ module.exports = function (data, done) {
               break;
             case 'notice':
               if (!data.options.showSummaryOnly && data.options.showNotices) {
-                data.grunt.log.writeln(indent + chalk.dim.bold('Notice: ') + item.message);
+                data.grunt.log.writeln(indent + chalk.white.bold('Notice: ') + item.message);
                 if (data.options.showDetails) {
                   data.grunt.log.writeln(indent + chalk.white.bold('Code: ') + item.code);
                   data.grunt.log.writeln(indent + chalk.white.bold('Context: ') + chalk.cyan(item.context));
@@ -115,11 +115,11 @@ module.exports = function (data, done) {
         data.grunt.log.writeln('');
 
         if (count.errors > 0) {
-          data.grunt.log.error(chalk.red.bold('Page conains ' + count.errors + ' major accessibility issue(s).'));
+          data.grunt.log.error(chalk.white.bold('Page conains ' + count.errors + ' major accessibility issue(s).'));
         }
       }
     } else {
-      data.grunt.log.ok(chalk.green.bold('Page appears to have no accessibility issues.'));
+      data.grunt.log.ok(chalk.white.bold('Page appears to have no accessibility issues.'));
     }
 
     done(null, data);

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -47,6 +47,7 @@ module.exports = function (data, done) {
   execFile(bin, ['a11y', '--path', data.file.file], function (error, result, code) {
     if (error) {
       data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.file);
+      data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -115,7 +115,7 @@ module.exports = function (data, done) {
         data.grunt.log.writeln('');
 
         if (count.errors > 0) {
-          data.grunt.log.error(chalk.white.bold('Page conains ' + count.errors + ' major accessibility issue(s).'));
+          data.grunt.log.error(chalk.white.bold('Page contains ' + count.errors + ' major accessibility issue(s).'));
         }
       }
     } else {

--- a/tasks/lib/audit-a11y.js
+++ b/tasks/lib/audit-a11y.js
@@ -44,7 +44,7 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['a11y', '--path', data.file.src], function (error, result, code) {
+  execFile('html-audit', ['a11y', '--path', data.file.src], function (error, result, code) {
     if (error) {
       data.grunt.log.writeln('Running:' + bin + ' a11y --path ' + data.file.src);
       data.grunt.log.writeln(chalk.red(error));

--- a/tasks/lib/audit-html5.js
+++ b/tasks/lib/audit-html5.js
@@ -44,7 +44,7 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['html5', '--path', data.file.src], function (error, result, code) {
+  execFile('html-audit', ['html5', '--path', data.file.src], function (error, result, code) {
     if (error) {
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));

--- a/tasks/lib/audit-html5.js
+++ b/tasks/lib/audit-html5.js
@@ -46,8 +46,8 @@ module.exports = function (data, done) {
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile(bin, ['html5', '--path', data.file.file], function (error, result, code) {
     if (error) {
-      data.logger(chalk.red(result));
-      data.logger(chalk.red(code));
+      data.grunt.log.writeln(chalk.red(result));
+      data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);
     }
 

--- a/tasks/lib/audit-html5.js
+++ b/tasks/lib/audit-html5.js
@@ -38,14 +38,14 @@ module.exports = function (data, done) {
   }
 
   data.grunt.log.writeln('');
-  data.grunt.log.writeln(chalk.yellow.bold('> Validating HTML5 markup...'));
+  data.grunt.log.writeln(chalk.white.bold('> Validating HTML5 markup...'));
   if (!data.options.showSummaryOnly) {
     data.grunt.log.writeln('');
   }
 
-  var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile('html-audit', ['html5', '--path', data.file.src], function (error, result, code) {
     if (error) {
+      data.grunt.log.writeln('Running: html-auditor html5 --path ' + data.file.src);
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
@@ -111,13 +111,13 @@ module.exports = function (data, done) {
         data.grunt.log.writeln('');
 
         if (count.errors > 0) {
-          data.grunt.log.error(chalk.red.bold('HTML5 markup contains ' + count.errors + ' validation error(s).'));
+          data.grunt.log.error(chalk.white.bold('HTML5 markup contains ' + count.errors + ' validation error(s).'));
         } else {
-          data.grunt.log.ok(chalk.green.bold('HTML5 markup appears valid, with ' + count.notices + ' notice(s).'));
+          data.grunt.log.ok(chalk.white.bold('HTML5 markup appears valid, with ' + count.notices + ' notice(s).'));
         }
       }
     } else {
-      data.grunt.log.ok(chalk.green.bold('HTML5 markup appears 100% valid.'));
+      data.grunt.log.ok(chalk.white.bold('HTML5 markup appears 100% valid.'));
     }
 
     done(null, data);

--- a/tasks/lib/audit-html5.js
+++ b/tasks/lib/audit-html5.js
@@ -44,7 +44,7 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['html5', '--path', data.file.file], function (error, result, code) {
+  execFile(bin, ['html5', '--path', data.file.src], function (error, result, code) {
     if (error) {
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
@@ -57,7 +57,7 @@ module.exports = function (data, done) {
     data.logger(chalk.yellow(JSON.stringify(results)));
 
     if (Object.keys(results).length > 0) {
-      var messages = results[data.file.file];
+      var messages = results[data.file.src];
       if (Object.keys(messages).length > 0) {
         var count = {
           errors: 0,

--- a/tasks/lib/audit-html5.js
+++ b/tasks/lib/audit-html5.js
@@ -46,6 +46,7 @@ module.exports = function (data, done) {
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile(bin, ['html5', '--path', data.file.file], function (error, result, code) {
     if (error) {
+      data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -49,8 +49,8 @@ module.exports = function (data, done) {
     data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.file + ' --base-uri ' + data.options.baseUri));
 
     if (error) {
-      data.logger(chalk.red(result));
-      data.logger(chalk.red(code));
+      data.grunt.log.writeln(chalk.red(result));
+      data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);
     }
 

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -45,8 +45,8 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['link', '--path', data.file.file, '--base-uri', data.options.baseUri], function (error, result, code) {
-    data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.file + ' --base-uri ' + data.options.baseUri));
+  execFile(bin, ['link', '--path', data.file.src, '--base-uri', data.options.baseUri], function (error, result, code) {
+    data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.src + ' --base-uri ' + data.options.baseUri));
 
     if (error) {
       data.grunt.log.writeln(chalk.red(error));
@@ -60,7 +60,7 @@ module.exports = function (data, done) {
     data.logger(chalk.yellow(JSON.stringify(results)));
 
     if (Object.keys(results).length > 0) {
-      var messages = results[data.file.file];
+      var messages = results[data.file.src];
       if (Object.keys(messages).length > 0) {
         var count = {
           errors: 0

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -49,6 +49,7 @@ module.exports = function (data, done) {
     data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.file + ' --base-uri ' + data.options.baseUri));
 
     if (error) {
+      data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
       data.grunt.fail.fatal(result, 1);

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -44,11 +44,9 @@ module.exports = function (data, done) {
     data.grunt.log.writeln('');
   }
 
-  var bin = process.cwd() + '/node_modules/.bin/html-audit';
   execFile('html-audit', ['link', '--path', data.file.src, '--base-uri', data.options.baseUri], function (error, result, code) {
-    data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.src + ' --base-uri ' + data.options.baseUri));
-
     if (error) {
+      data.logger(chalk.yellow('html-audit link --path ' + data.file.src + ' --base-uri ' + data.options.baseUri));
       data.grunt.log.writeln(chalk.red(error));
       data.grunt.log.writeln(chalk.red(result));
       data.grunt.log.writeln(chalk.red(code));
@@ -85,12 +83,12 @@ module.exports = function (data, done) {
         data.grunt.log.writeln('');
 
         if (count.errors > 0) {
-          data.grunt.log.error(chalk.red.bold('Markup contains ' + count.errors + ' invalid URL(s).'));
+          data.grunt.log.error(chalk.white.bold('Markup contains ' + count.errors + ' invalid URL(s).'));
         }
       }
     } else {
       data.grunt.log.writeln('');
-      data.grunt.log.ok(chalk.green.bold('Links appear to be 100% valid.'));
+      data.grunt.log.ok(chalk.white.bold('Links appear to be 100% valid.'));
     }
 
     done(null, data);

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -45,7 +45,7 @@ module.exports = function (data, done) {
   }
 
   var bin = process.cwd() + '/node_modules/.bin/html-audit';
-  execFile(bin, ['link', '--path', data.file.src, '--base-uri', data.options.baseUri], function (error, result, code) {
+  execFile('html-audit', ['link', '--path', data.file.src, '--base-uri', data.options.baseUri], function (error, result, code) {
     data.logger(chalk.yellow(bin + ' link ' + '--path ' + data.file.src + ' --base-uri ' + data.options.baseUri));
 
     if (error) {

--- a/tasks/lib/audit-link.js
+++ b/tasks/lib/audit-link.js
@@ -38,7 +38,7 @@ module.exports = function (data, done) {
   }
 
   data.grunt.log.writeln('');
-  data.grunt.log.writeln(chalk.yellow.bold('> Validating links...'));
+  data.grunt.log.writeln(chalk.white.bold('> Validating links...'));
   data.grunt.log.writeln(chalk.dim(indent + 'Base URL: ' + data.options.baseUri));
   if (!data.options.showSummaryOnly) {
     data.grunt.log.writeln('');


### PR DESCRIPTION
- Fix an issue with running tasks using locally installed binary for `html-auditor`;
- Tone down over the top colour usage, using `chalk` package;
- Improve fatal error handling/logging when executing `html-auditor` binary;